### PR TITLE
issue-13: Fixed keypress detection in firefox.

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -44,7 +44,7 @@ function wtEasyMask($parse, $log, easyMask) {
                 return parsedValue === '' ? null : parsedValue;
             });
 
-            element.on('keypress', function (event) {
+            element.on('keyup', function (event) {
                 var keyIsEnter = event.which === 13;
                 if (keyIsEnter) return;
 


### PR DESCRIPTION
#13 PR

Fixed keypress detection in firefox with keyup as opposed to keypress. I tested it and it appears to be working again, though I encourage you to double check my work. :) 
